### PR TITLE
Optimize buildCombinedRegex Function

### DIFF
--- a/src/js/core/scanner.js
+++ b/src/js/core/scanner.js
@@ -7,24 +7,36 @@ function normalizeKeywords(keywordList) {
 }
 
 function buildCombinedRegex(validKeywords) {
-    const patterns = [];
-    const patternMap = [];
+    if (validKeywords.length === 0) {
+        return null;
+    }
 
-    validKeywords.forEach((word, index) => {
-        try {
-            // Validate regex
-            new RegExp(word);
-            patterns.push(`(?<k${index}>${word})`);
-            patternMap[index] = word;
-        } catch (_e) {
-            // ignore invalid regex entry
-        }
-    });
-
-    if (patterns.length === 0) return null;
-
+    const patterns = validKeywords.map((word, index) => `(?<k${index}>${word})`);
     const combinedPattern = patterns.join('|');
-    return { regex: new RegExp(combinedPattern, 'ig'), patternMap };
+
+    try {
+        const regex = new RegExp(combinedPattern, 'ig');
+        return { regex, patternMap: validKeywords };
+    } catch (e) {
+        // Fallback for when an invalid keyword is present
+        const validPatterns = [];
+        const patternMap = [];
+        validKeywords.forEach((word, index) => {
+            try {
+                new RegExp(word);
+                validPatterns.push(`(?<k${index}>${word})`);
+                patternMap[index] = word;
+            } catch (_e) {
+                // ignore invalid regex entry
+            }
+        });
+
+        if (validPatterns.length === 0) {
+            return null;
+        }
+        const newCombinedPattern = validPatterns.join('|');
+        return { regex: new RegExp(newCombinedPattern, 'ig'), patternMap };
+    }
 }
 
 function scanTextForKeywords(keywordList, textToScan) {


### PR DESCRIPTION
This change optimizes the `buildCombinedRegex` function in `src/js/core/scanner.js` to avoid creating a new RegExp object for every keyword, which is inefficient for large lists. It now attempts to create a single, combined regular expression and falls back to the original, slower method of validating each keyword individually if an invalid regex pattern is present. This significantly improves performance for the common case where all keywords are valid.

---
*PR created automatically by Jules for task [17704337047264674774](https://jules.google.com/task/17704337047264674774) started by @viseshrp*